### PR TITLE
Fix broken test

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,7 +5,7 @@ function array(w = CANVAS_WIDTH, h = CANVAS_HEIGHT) {
 }
 
 function fill(arr, symbol, ncol) {
-  return arr.map(row => row.map((char, j) => (j % ncol === 0 ? symbol : "")));
+  return arr.map(row => row.map((char, j) => (j % ncol === 0 ? symbol : " ")));
 }
 
 function stringify(arr) {


### PR DESCRIPTION
The `init › should fill canvas with alternating symbol` test was failing with empty-strings in the received array, instead of spaces.

This fix makes the tests work, by padding in the 'fill' function, I hope that's what you had intended...